### PR TITLE
fix data type

### DIFF
--- a/http-status-counter.go
+++ b/http-status-counter.go
@@ -108,7 +108,7 @@ type HTTPStatusCounterPlugin struct {
 // HTTPStatusCounterOutput http-status-counter metrics
 type HTTPStatusCounterOutput struct {
 	Status                      map[string]int
-	BodyBytesSent               int     `json:"body_bytes_sent"`
+	BodyBytesSent               uint64  `json:"body_bytes_sent"`
 	AverageRequestTime          float64 `json:"avg_request_time"`
 	AverageUpstreamResponseTime float64 `json:"avg_upstream_response_time"`
 }


### PR DESCRIPTION
`linux/386`  でビルドし実行したら以下のようなエラーがでました。

```
$ ./mackerel-plugin-http-status-counter
2017/03/10 15:26:41 OutputValues:  json: cannot unmarshal number 8767426406 into Go value of type int
```

他の定義を見るとuinit64のようなので修正します。